### PR TITLE
Bugfix: multiple PTM types on same sequence

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: PlexedPiper
 Type: Package
 Title: Pipeline for isobaric quantification
-Version: 0.4.0
-Date: 2023-01-09
+Version: 0.4.1
+Date: 2023-02-07
 Author: Vladislav Petyuk vladislav.petyuk@pnnl.gov
 Maintainer: Vladislav Petyuk <vladislav.petyuk@pnnl.gov>
 Description: Pipeline for isobaric quantification.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# PlexedPiper 0.4.1 (2023-02-07)
+
+-   Removed duplicate GENCODE protein IDs from `run_plexedpiper` output. GENCODE IDs are currently only unique when combining the protein (ENSP) and transcript (ENST) IDs. Since there are so few duplicates, we will remove them rather than concatenating these IDs in the "protein_id" column of the output of `make_results_ratio_*` and `make_rii_peptide_*` functions.
+-   Shortened UniProt headers in `run_plexedpiper` output to only use the middle portion of the UniProt IDs.
+-   Bugfix: fixed parsing of crosstab rownames in `make_rii_peptide_ph` when acetylated peptides also contain PTMs denoted by a "\@".
+-   Requires an update to a version of [MSnID](https://github.com/PNNL-Comp-Mass-Spec/MSnID) built on or after 2023-01-26 when column "unique_id" was added to `parse_FASTA_names` output.
+
 # PlexedPiper 0.4.0 (2023-01-09)
 
 -   Updated MoTrPAC BIC functions to extract information from GENCODE FASTA headers and include them as columns in results tables.

--- a/R/motrpac_bic_funtions.R
+++ b/R/motrpac_bic_funtions.R
@@ -379,11 +379,16 @@ make_rii_peptide_ph <- function(msnid,
   )
 
   ## Create RII peptide table
+  # Some peptides may be ubiquitinated (#) as well as acetylated (@),
+  # so we cannot use tidyr::separate with sep = "@". We use flanking AAs as
+  # anchors for the regex instead.
+  pttrn <- "(^.*)@([A-Z\\-]{1}\\..*\\.[A-Z\\-]{1})@(.*)"
   feature_data <- crosstab %>%
     dplyr::select(Specie) %>%
-    tidyr::separate(Specie, into = c("protein_id", "sequence", "ptm_id"),
-                    sep = "@", remove = FALSE) %>%
-    mutate(ptm_peptide = paste(ptm_id, sequence, sep = sep),
+    mutate(protein_id = sub(pttrn, "\\1", Specie),
+           sequence = sub(pttrn, "\\2", Specie),
+           ptm_id = sub(pttrn, "\\3", Specie),
+           ptm_peptide = paste(ptm_id, sequence, sep = sep),
            organism_name = org_name)
 
   if (annotation == "REFSEQ") {


### PR DESCRIPTION
In some MoTrPAC acetylation data, some peptides were also ubiquitinated ("@"). This led to a mistake when parsing the crosstab rownames, as it would split the identifiers into 3 columns using the "@" symbol. This has been fixed so that the flanking amino acids are treated as anchors in the regex to parse the identifiers.